### PR TITLE
Add auth token

### DIFF
--- a/src/transformer_deploy/convert.py
+++ b/src/transformer_deploy/convert.py
@@ -48,10 +48,14 @@ def main():
         description="optimize and deploy transformers", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument("-m", "--model", required=True, help="path to model or URL to Hugging Face Hub")
-    parser.add_argument("--auth-token", default=None, help=(
-        "HuggingFace Hub auth token. Set to `None` (default) for public models. "
-        "For private models, use `True` to use local cached token, or a string of your HF API token"
-    ))
+    parser.add_argument(
+        "--auth-token",
+        default=None,
+        help=(
+            "HuggingFace Hub auth token. Set to `None` (default) for public models. "
+            "For private models, use `True` to use local cached token, or a string of your HF API token"
+        ),
+    )
     parser.add_argument(
         "-b",
         "--batch-size",
@@ -103,9 +107,7 @@ def main():
     tensorrt_path = os.path.join(args.output, "model.plan")
 
     assert torch.cuda.is_available(), "CUDA is not available. Please check your CUDA installation"
-    tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(
-        args.model, use_auth_token=auth_token
-    )
+    tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(args.model, use_auth_token=auth_token)
     input_names: List[str] = tokenizer.model_input_names
     logging.info(f"axis: {input_names}")
     include_token_ids = "token_type_ids" in input_names

--- a/src/transformer_deploy/convert.py
+++ b/src/transformer_deploy/convert.py
@@ -90,12 +90,12 @@ def main():
 
     torch.manual_seed(args.seed)
 
-    if args.auth_token is None:
-        auth_token = None
-    elif args.auth_token.lower() in ["true", "t"]:
+    if isinstance(args.auth_token, str) and args.auth_token.lower() in ["true", "t"]:
         auth_token = True
-    else:
+    elif isinstance(args.auth_token, str):
         auth_token = args.auth_token
+    else:
+        auth_token = None
 
     Path(args.output).mkdir(parents=True, exist_ok=True)
     onnx_model_path = os.path.join(args.output, "model-original.onnx")


### PR DESCRIPTION
add CLI argument and a little parsing. This allows using private models from the huggingface hub. Resolves #17 

Note this is untested for now. If anyone has a private model that they know should work with transformer-deploy, that would be great. Otherwise, I can make a private repo with the example model.