### PR TITLE
Fix install errors

### DIFF
--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -4,6 +4,7 @@ nvidia-pyindex
 tritonclient[all]
 pycuda
 torch==1.10.0+cu113
+nvidia-pyindex
 nvidia-tensorrt
 onnx_graphsurgeon
 polygraphy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[metadata]
+setup_requires =
+    wheel
+
 [isort]
 ensure_newline_before_comments = True
 force_grid_wrap = 0


### PR DESCRIPTION
Update `requirements_gpu.txt` and add `nvidia-pyindex` to GPU requirements, so `nvidia-tensorrt` install works. Also add the wheel requirement to setup.cfg.

Without explicitly adding `nvidia-pyindex`, following the install commands gives the following (which includes `nvidia-pyindex`, so I am not sure why adding it explicitly is needed)

```sh
person@machine:~/transformer-deploy$ pip install ".[GPU]" -f https://download.pytorch.org/whl/cu113/torch_stable.html
Looking in links: https://download.pytorch.org/whl/cu113/torch_stable.html
Processing /home/person/transformer-deploy
Requirement already satisfied: black in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (21.12b0)
Requirement already satisfied: colored in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (1.4.3)
Requirement already satisfied: coloredlogs in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (15.0.1)
Requirement already satisfied: fastapi in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (0.70.0)
Requirement already satisfied: flake8 in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (4.0.1)
Requirement already satisfied: gunicorn in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (20.1.0)
Requirement already satisfied: isort in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (5.10.1)
Requirement already satisfied: numpy in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (1.21.4)
Requirement already satisfied: pytest in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (6.2.5)
Requirement already satisfied: requests in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (2.26.0)
Requirement already satisfied: sentencepiece in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (0.1.96)
Requirement already satisfied: sympy in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (1.9)
Requirement already satisfied: transformers in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (4.12.5)
Requirement already satisfied: uvicorn in ./venv/lib/python3.8/site-packages (from transformer-deploy==0.1.1) (0.15.0)
Collecting nvidia-pyindex
  Using cached nvidia-pyindex-1.0.9.tar.gz (10 kB)
Collecting nvidia-tensorrt
  Using cached nvidia-tensorrt-0.0.1.dev5.tar.gz (7.9 kB)
    ERROR: Command errored out with exit status 1:
     command: /home/person/transformer-deploy/venv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-vyjw_vff/nvidia-tensorrt/setup.py'"'"'; __file__='"'"'/tmp/pip-install-vyjw_vff/nvidia-tensorrt/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-vyjw_vff/nvidia-tensorrt/pip-egg-info
         cwd: /tmp/pip-install-vyjw_vff/nvidia-tensorrt/
    Complete output (16 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-vyjw_vff/nvidia-tensorrt/setup.py", line 150, in <module>
        raise RuntimeError(open("ERROR.txt", "r").read())
    RuntimeError:
    ###########################################################################################
    The package you are trying to install is only a placeholder project on PyPI.org repository.
    This package is hosted on NVIDIA Python Package Index.

    This package can be installed as:
    ```
    $ pip install nvidia-pyindex
    $ pip install nvidia-tensorrt
    ```
    ###########################################################################################

    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

I added wheel to the setup.cfg because otherwise the install command throws a lot of errors like this:

```
  Building wheel for nvidia-cudnn-cu11 (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/sam_havens/transformer-deploy/venv/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-jhkjxofw/nvidia-cudnn-cu11/setup.py'"'"'; __file__='"'"'/tmp/pip-install-jhkjxofw/nvidia-cudnn-cu11/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-gzao50sp
       cwd: /tmp/pip-install-jhkjxofw/nvidia-cudnn-cu11/
  Complete output (6 lines):
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help

  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for nvidia-cudnn-cu11
```