### PR TITLE
fix: force order of ops in fp16 conversion audit

### DIFF
--- a/src/transformer_deploy/backends/ort_utils.py
+++ b/src/transformer_deploy/backends/ort_utils.py
@@ -300,7 +300,7 @@ def find_node_fp32(graph: Dict[str, str], output_nodes: Dict[str, torch.Tensor])
         if (
             torch.any(tensor > max_float16)
             or torch.any(tensor < min_float16)
-            or (torch.any(tensor < resolution & tensor > -resolution & tensor != 0))  # limited memory footprint
+            or (torch.any((tensor < resolution) & (tensor > -resolution) & (tensor != 0)))  # limited memory footprint
         ):
             keep_fp32.append(graph[k])
     return keep_fp32


### PR DESCRIPTION
fix #78 by forcing order of ops in fp16 conversion audit