### PR TITLE
fix: fix authentication for private models

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ More examples of inference can be found in demo/question-answering/
 Feature extraction in NLP is the task to convert text to dense embeddings.  
 It has gained some traction as a robust way to improve search engine relevancy (increase recall).  
 This project supports models from [sentence-transformers](https://github.com/UKPLab/sentence-transformers).
+If you want to use private models from sentence-transformers, you'll need at least the V2.2.0 version.
 
 #### Optimize existing model
 

--- a/README.md
+++ b/README.md
@@ -274,9 +274,8 @@ More examples of inference can be found in demo/question-answering/
 
 Feature extraction in NLP is the task to convert text to dense embeddings.  
 It has gained some traction as a robust way to improve search engine relevancy (increase recall).  
-This project supports models from [sentence-transformers](https://github.com/UKPLab/sentence-transformers).
-If you want to use private models from sentence-transformers, you'll need at least the V2.2.0 version.
-
+This project supports models from [sentence-transformers](https://github.com/UKPLab/sentence-transformers) and it requires 
+a version >= V2.2.0 of sentence-transformers library.
 #### Optimize existing model
 
 ```shell

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ black[jupyter]
 isort
 flake8
 onnxoptimizer
+packaging

--- a/src/transformer_deploy/backends/st_utils.py
+++ b/src/transformer_deploy/backends/st_utils.py
@@ -53,13 +53,23 @@ def load_sentence_transformers(path: str, use_auth_token: str = None) -> STransf
     """
     Load sentence-transformers model and wrap it to make it behave like any other transformers model
     :param path: path to the model
+    :param use_auth_token: authentication token used to access private models
     :return: wrapped sentence-transformers model
     """
     try:
-        from sentence_transformers import SentenceTransformer
+        import sentence_transformers
     except ImportError:
         raise Exception(
-            "sentence-transformers library is not present, please install it: pip install sentence-transformers"
+            "sentence-transformers library is not present, you can install it using: "
+            "pip install sentence-transformers==2.2.0 (or a greater version)"
         )
-    model: SentenceTransformer = SentenceTransformer(model_name_or_path=path, use_auth_token=use_auth_token)
+    from packaging import version
+
+    assert version.parse(sentence_transformers.__version__) >= version.parse("2.2.0"), (
+        f"sentence-transformers library's version is {sentence_transformers.__version__}, "
+        f"you need at least the V2.2.0 version"
+    )
+    model: SentenceTransformer = sentence_transformers.SentenceTransformer(
+        model_name_or_path=path, use_auth_token=use_auth_token
+    )
     return STransformerWrapper(model=model)

--- a/src/transformer_deploy/backends/st_utils.py
+++ b/src/transformer_deploy/backends/st_utils.py
@@ -49,7 +49,7 @@ class STransformerWrapper(nn.Module):
         return outputs["sentence_embedding"]
 
 
-def load_sentence_transformers(path: str) -> STransformerWrapper:
+def load_sentence_transformers(path: str, use_auth_token: str = None) -> STransformerWrapper:
     """
     Load sentence-transformers model and wrap it to make it behave like any other transformers model
     :param path: path to the model
@@ -61,5 +61,5 @@ def load_sentence_transformers(path: str) -> STransformerWrapper:
         raise Exception(
             "sentence-transformers library is not present, please install it: pip install sentence-transformers"
         )
-    model: SentenceTransformer = SentenceTransformer(path)
+    model: SentenceTransformer = SentenceTransformer(model_name_or_path=path, use_auth_token=use_auth_token)
     return STransformerWrapper(model=model)

--- a/src/transformer_deploy/convert.py
+++ b/src/transformer_deploy/convert.py
@@ -160,10 +160,14 @@ def main(commands: argparse.Namespace):
         assert torch.cuda.is_available(), "CUDA/GPU is not available on Pytorch. Please check your CUDA installation"
     tokenizer_path = commands.tokenizer if commands.tokenizer else commands.model
     tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_auth_token=auth_token)
-    model_config: PretrainedConfig = AutoConfig.from_pretrained(pretrained_model_name_or_path=commands.model)
+    model_config: PretrainedConfig = AutoConfig.from_pretrained(
+        pretrained_model_name_or_path=commands.model, use_auth_token=auth_token
+    )
     input_names: List[str] = tokenizer.model_input_names
     if commands.task == "embedding":
-        model_pytorch: Union[PreTrainedModel, STransformerWrapper] = load_sentence_transformers(commands.model)
+        model_pytorch: Union[PreTrainedModel, STransformerWrapper] = load_sentence_transformers(
+            commands.model, use_auth_token=auth_token
+        )
     elif commands.task == "classification":
         model_pytorch = AutoModelForSequenceClassification.from_pretrained(commands.model, use_auth_token=auth_token)
     elif commands.task == "token-classification":


### PR DESCRIPTION
Authentication token is not used for loading configuration and Sentence Transformers models.
The authentication token was added for Sentence Transformers models starting from V2.2.0 version

fixes #132 