### PR TITLE
fix: expose load_external_data for large models

### DIFF
--- a/demo/generative-model/t5_tensorrt.py
+++ b/demo/generative-model/t5_tensorrt.py
@@ -34,6 +34,8 @@ from transformer_deploy.backends.trt_utils import TensorRTShape, build_engine, l
 # TODO pre allocate the largest possible past states and reuse it with tensorrt
 # https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#reusing-input-buffers
 # https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#empty-tensors
+# load_external_data should be set to True for large models (> 2Gb)
+load_external_data = False
 model_name = "t5-small"
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 input_ids: torch.Tensor = tokenizer(
@@ -61,6 +63,7 @@ convert_to_onnx(
     var_output_seq=True,
     quantization=False,
     output_names=["output"],
+    load_external_data=load_external_data,
 )
 
 enc_onnx = create_model_for_provider("test-enc.onnx", "CUDAExecutionProvider")

--- a/src/transformer_deploy/backends/pytorch_utils.py
+++ b/src/transformer_deploy/backends/pytorch_utils.py
@@ -89,7 +89,7 @@ def convert_to_onnx(
     quantization: bool,
     var_output_seq: bool,
     output_names: List[str],
-    load_external_data: bool = False
+    load_external_data: bool = False,
 ) -> None:
     """
     Convert a Pytorch model to an ONNX graph by tracing the provided input inside the Pytorch code.

--- a/src/transformer_deploy/backends/pytorch_utils.py
+++ b/src/transformer_deploy/backends/pytorch_utils.py
@@ -89,6 +89,7 @@ def convert_to_onnx(
     quantization: bool,
     var_output_seq: bool,
     output_names: List[str],
+    load_external_data: bool = False
 ) -> None:
     """
     Convert a Pytorch model to an ONNX graph by tracing the provided input inside the Pytorch code.
@@ -165,7 +166,7 @@ def convert_to_onnx(
             training=TrainingMode.EVAL,  # always put the model in evaluation mode
             verbose=False,
         )
-    proto = onnx.load(output_path, load_external_data=False)
+    proto = onnx.load(output_path, load_external_data=load_external_data)
     save_onnx(proto=proto, model_path=output_path)
     if quantization:
         TensorQuantizer.use_fb_fake_quant = False

--- a/src/transformer_deploy/convert.py
+++ b/src/transformer_deploy/convert.py
@@ -207,6 +207,7 @@ def main(commands: argparse.Namespace):
         quantization=commands.quantization,
         var_output_seq=commands.task in ["text-generation", "token-classification", "question-answering"],
         output_names=["output"] if commands.task != "question-answering" else ["start_logits", "end_logits"],
+        load_external_data=commands.load_external_data
     )
 
     timings = {}

--- a/src/transformer_deploy/convert.py
+++ b/src/transformer_deploy/convert.py
@@ -207,7 +207,7 @@ def main(commands: argparse.Namespace):
         quantization=commands.quantization,
         var_output_seq=commands.task in ["text-generation", "token-classification", "question-answering"],
         output_names=["output"] if commands.task != "question-answering" else ["start_logits", "end_logits"],
-        load_external_data=commands.load_external_data
+        load_external_data=commands.load_external_data,
     )
 
     timings = {}

--- a/src/transformer_deploy/utils/args.py
+++ b/src/transformer_deploy/utils/args.py
@@ -46,12 +46,12 @@ def parse_args(commands: List[str] = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "-l",
         "--load-external-data",
         default=False,
         help="whether to load external data. It may be used for loading large models (> 2 Gb).",
-        type=bool,
+        action='store_true'
     )
+    parser.add_argument('--no-load-external-data', dest='load_external_data', action='store_false')
     parser.add_argument(
         "-b",
         "--batch-size",

--- a/src/transformer_deploy/utils/args.py
+++ b/src/transformer_deploy/utils/args.py
@@ -49,9 +49,9 @@ def parse_args(commands: List[str] = None) -> argparse.Namespace:
         "--load-external-data",
         default=False,
         help="whether to load external data. It may be used for loading large models (> 2 Gb).",
-        action='store_true'
+        action="store_true",
     )
-    parser.add_argument('--no-load-external-data', dest='load_external_data', action='store_false')
+    parser.add_argument("--no-load-external-data", dest="load_external_data", action="store_false")
     parser.add_argument(
         "-b",
         "--batch-size",

--- a/src/transformer_deploy/utils/args.py
+++ b/src/transformer_deploy/utils/args.py
@@ -50,7 +50,7 @@ def parse_args(commands: List[str] = None) -> argparse.Namespace:
         "--load-external-data",
         default=False,
         help="whether to load external data. It may be used for loading large models (> 2 Gb).",
-        type=bool
+        type=bool,
     )
     parser.add_argument(
         "-b",

--- a/src/transformer_deploy/utils/args.py
+++ b/src/transformer_deploy/utils/args.py
@@ -46,6 +46,13 @@ def parse_args(commands: List[str] = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "-l",
+        "--load-external-data",
+        default=False,
+        help="whether to load external data. It may be used for loading large models (> 2 Gb).",
+        type=bool
+    )
+    parser.add_argument(
         "-b",
         "--batch-size",
         default=[1, 1, 1],


### PR DESCRIPTION
Tested on cloud-dev with roberta-large.
closes #138 